### PR TITLE
fix: use correct return type for `assert.waitFor`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,9 +49,6 @@ export function installWaitFor(QUnit: QUnit) {
 
 declare global {
   interface Assert {
-    waitFor(
-      callback: AssertionCallback,
-      options?: Options
-    ): () => Promise<void>;
+    waitFor(callback: AssertionCallback, options?: Options): Promise<void>;
   }
 }

--- a/tests/wait-for-test.js
+++ b/tests/wait-for-test.js
@@ -1,4 +1,3 @@
-const QUnit = require("qunit");
 const td = require("testdouble");
 const installVerify = require("testdouble-qunit");
 const { installWaitFor } = require("../pkg");


### PR DESCRIPTION
Closes #8