### PR TITLE
Add "qunit-plugin" keyword to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "Wait for a QUnit assertion",
   "author": "Alex LaFroscia <alex@lafroscia.com>",
   "license": "MIT",
+  "keywords": [
+    "qunit",
+    "qunit-plugin"
+  ],
   "scripts": {
     "build": "pika build",
     "fmt": "prettier --write .",


### PR DESCRIPTION
Once in a patch release or other release, this will make
the plugin be able to show up on <https://qunitjs.com/plugins/>.

Thanks for making this plugin!